### PR TITLE
ci/move workflows to root directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./elice-free-fe
+        working-directory: elice-tree-fe
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./elice-free-fe
+        working-directory: elice-tree-fe
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What this PR does

root directory로 workflow file들을 옮겼습니다.

## Description for the change log

root directory에 .github/workflows를 배치해야만 github actions가 동작한다고 합니다.



참고: https://stackoverflow.com/questions/62288443/where-should-you-put-the-git-hub-workflow-directory-for-actions-in-a-full-stack

## Related Issues
